### PR TITLE
Fix robot

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -19,7 +19,7 @@ if (process.env.NODE_ENV === 'production'){
   });
 
   app.use(noindex);
-  //app.use(auth);
+  app.use(auth);
 
   // make express look in the public directory for assets
   app.use(express.static(path.join(__dirname, '..')));


### PR DESCRIPTION
Removed mr.robot from the server.js requirements. Heroku logs showed that it was looking for the mr.robot module. We are not using mr.robot, therefore it isn't necessary to keep.