### PR TITLE
refactor: fix links to primary font Avenir Next in _fonts.scss

### DIFF
--- a/source/scss/_fonts.scss
+++ b/source/scss/_fonts.scss
@@ -1,15 +1,16 @@
 // TYPOGRAPHY
 
-@font-face {
-  font-family: "Avenir Next";
-  src:url("fonts/6fb51c51-e183-4721-9e37-45a2ba8a5641.eot?#iefix");
-  src:url("fonts/6fb51c51-e183-4721-9e37-45a2ba8a5641.eot?#iefix") format("eot"),
-      url("fonts/9ddb7916-058a-4e43-9880-dcb237ef42b6.woff") format("woff"),
-      url("fonts/39e32aa7-13e2-40ab-ac9c-ea669789b9d6.ttf") format("truetype"),
-      url("fonts/4c639ff3-732a-4d7a-b793-b83771f8e94c.svg#4c639ff3-732a-4d7a-b793-b83771f8e94c") format("svg");
-  font-weight: bold;
-  font-style: normal;
-}
+@import url("http://fast.fonts.net/t/1.css?apiType=css&projectid=d7a55a73-a4db-4229-b108-7ab309bb5e8a");
+    @font-face{
+        font-family:"AvenirNextLTW01-Medium";
+        src:url("Fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot?#iefix");
+        src:url("Fonts/1a7c9181-cd24-4943-a9d9-d033189524e0.eot?#iefix") format("eot"),url("Fonts/627fbb5a-3bae-4cd9-b617-2f923e29d55e.woff2") format("woff2"),url("Fonts/f26faddb-86cc-4477-a253-1e1287684336.woff") format("woff"),url("Fonts/63a74598-733c-4d0c-bd91-b01bffcd6e69.ttf") format("truetype"),url("Fonts/a89d6ad1-a04f-4a8f-b140-e55478dbea80.svg#a89d6ad1-a04f-4a8f-b140-e55478dbea80") format("svg");
+    }
+    @font-face{
+        font-family:"Avenir Next LT W01 Bold";
+        src:url("Fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?#iefix");
+        src:url("Fonts/dccb10af-07a2-404c-bfc7-7750e2716bc1.eot?#iefix") format("eot"),url("Fonts/14c73713-e4df-4dba-933b-057feeac8dd1.woff2") format("woff2"),url("Fonts/b8e906a1-f5e8-4bf1-8e80-82c646ca4d5f.woff") format("woff"),url("Fonts/890bd988-5306-43ff-bd4b-922bc5ebdeb4.ttf") format("truetype"),url("Fonts/ed104d8c-7f39-4e8b-90a9-4076be06b857.svg#ed104d8c-7f39-4e8b-90a9-4076be06b857") format("svg");
+    }
 
 @mixin primary-font() {
   font-family: "Avenir Next", "Helvetica Neue", Arial, sans-serif;
@@ -26,3 +27,10 @@
     font-weight: 500;
   }
 }
+
+/*
+This CSS resource incorporates links to font software which is the valuable copyrighted
+property of Monotype Imaging and/or its suppliers. You may not attempt to copy, install,
+redistribute, convert, modify or reverse engineer this font software. Please contact Monotype
+Imaging with any questions regarding Web Fonts:  http://www.fonts.com
+*/


### PR DESCRIPTION
### The issue: 
The primary font, Avenir Next does not render in Firefox or Android 4.0 device web browsers.

### Solution:
This PR updates _fonts.scss. The primary font, Avenir Next, imports from fonts.com.

### To test:
_npm install_ to install dependencies
_npm run dev_ to launch the development server

The development server will launch in your default web browser. If this is not Firefox, open Firefox and go to http://localhost:3000 to review.

A screen shot of 'Meat Hut' in Avenir Next is provided for reference.
![screen shot 2017-06-20 at 4 18 46 pm](https://user-images.githubusercontent.com/12678977/27354061-4e66cc84-55d4-11e7-8689-a73d06baffb7.png)
