### PR TITLE
Node upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "apprenticeProject2017",
   "version": "1.0.0",
+  "engines": {
+    "node": "6.11.1"
+  },
   "description": "An aggregate of Sparkboxer's reviews of places to eat and drink.",
   "main": "server.js",
   "scripts": {


### PR DESCRIPTION
### This pull request resolves issue #134.

An `engines` section has been added to the `package.json` file specifying Node.js version 6.11.1.
I then ran `yarn upgrade` in the terminal thus updating the `yarn.lock` file and implementing the changes.

Reference document used: https://devcenter.heroku.com/articles/nodejs-support#specifying-a-node-js-version

### How to detect what version of node sparkeats is running:

In the terminal run `heroku run node -v -a sparkeats`.
Expected output:
![node version](https://user-images.githubusercontent.com/12678977/28174564-ce826368-67bf-11e7-9ebd-c4c2832334e5.png)
