### PR TITLE
feat: complete styling of the navigation buttons on the review page

### DIFF
--- a/source/partials/_review-container.hbs
+++ b/source/partials/_review-container.hbs
@@ -2,5 +2,5 @@
   {{> _review-header places.table-33 }}
   {{> _review-submission reviews.table-33 }}
   {{> _review-overview places.table-33 }}
+  {{> _review-nav}}
 </section>
-{{> _review-nav}}

--- a/source/partials/_review-nav.hbs
+++ b/source/partials/_review-nav.hbs
@@ -1,0 +1,10 @@
+<!-- TODO: add functionality to the Next Place button -->
+
+<div class="review-nav">
+  <div class="review-nav__button review-nav__button-span">
+    <a class="review-nav__link" href="/index.html" role="button">Home</a>
+  </div>
+  <div class="review-nav__button">
+    <a class="review-nav__link" href="#" role="button">Next Place</a>
+  </div>
+</div>

--- a/source/scss/_review.scss
+++ b/source/scss/_review.scss
@@ -158,3 +158,38 @@
     }
   }
 }
+
+.review-nav {
+  padding-left: 0;
+  margin: 0 auto;
+  max-width: 58.5em;
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+  @media (min-width: 48em) {
+    display: block;
+    max-width: 66.5%;
+    float: left;
+  }
+  &__button {
+    display: inline-block;
+    background-color: $color-fountain-blue;
+    width: 37%;
+    padding: 1em;
+    text-align: center;
+    @media (min-width: 48em) {
+      &-span {
+        margin: 0 1em 0 0;
+      }
+    }
+  }
+  &__link {
+    @include primary-font();
+    color: $color-sparkblue-dark;
+    text-decoration: none;
+    font-size: 1.25em;
+    &:visited {
+      color: $color-white;
+    }
+  }
+}


### PR DESCRIPTION
#### This pull request fulfills issue #55 by creating the handlebars partials and styling for the `Home` and `Next Place` navigational buttons at the bottom of the review page.

The expected output should look like this on smaller devices:
![screen shot 2017-07-14 at 1 25 50 pm](https://user-images.githubusercontent.com/12678977/28223106-0c7cee12-6898-11e7-87ba-d7ddd2194b0b.png)

And like this on larger devices:
![screen shot 2017-07-14 at 1 26 11 pm](https://user-images.githubusercontent.com/12678977/28223109-128f55d8-6898-11e7-9d73-cdecd0cfbad7.png)
