### PR TITLE
Fixes Issue #133: Investigate and fix Circle CI failures

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 6.11.1


### PR DESCRIPTION
Turns out that we needed to create a circle.yml file in the project home folder and specify the version of Node we're using. It was using the default (4.2.6), which is much lower than ours (6.11.1).