### PR TITLE
feat: add place-image-alt tag content

### DIFF
--- a/source/partials/_place-card--image.hbs
+++ b/source/partials/_place-card--image.hbs
@@ -1,5 +1,5 @@
 <header class="place-card__header">
   <a href="{{getReviewPageLink place-id}}">
-    <img class="place-card__image" src={{getImageLocation place.place-image 'place'}} alt="{{getImageAltTag place.place-image-alt place.place-name}}"/>
+    <img class="place-card__image" src={{getImageLocation place.place-image 'place'}} alt="{{getPlaceImageAlt place.place-image-alt place.place-name}}"/>
   </a>
 </header>

--- a/tasks/lib/sparkeats-handlebars-helpers.js
+++ b/tasks/lib/sparkeats-handlebars-helpers.js
@@ -65,7 +65,7 @@ module.exports.register = function (Handlebars) {
     return review['review-image-alt'][reviewImageIndex];
   });
 
-  Handlebars.registerHelper('getImageAltTag', (placeImageAlt, placeName) => {
+  Handlebars.registerHelper('getPlaceImageAlt', (placeImageAlt, placeName) => {
     if (!placeImageAlt) {
       return `${placeName}`;
     }

--- a/tasks/lib/sparkeats-handlebars-helpers.spec.js
+++ b/tasks/lib/sparkeats-handlebars-helpers.spec.js
@@ -187,16 +187,22 @@ describe('getReviewImageAlt', () => {
   });
 });
 
-describe('getImageAltTag', () => {
+describe('getPlaceImageAlt', () => {
   before(() => {
-    html = '{{getImageAltTag place-image-alt place-name}}';
+    html = '{{getPlaceImageAlt place-image-alt place-name}}';
     template = Handlebars.compile(html);
     result = (placeImageAlt, placeName) => template({ 'place-image-alt': placeImageAlt, 'place-name': placeName });
   });
   it('should return as a string', () => {
-    expect(result('text alt description')).to.be.a('string');
+    expect(result('text alt description', 'place-name value')).to.be.a('string');
   });
   it('should not be empty', () => {
-    expect(result('text alt description II')).to.not.be.empty;
+    expect(result('text alt description II', 'place-name value')).to.not.be.empty;
+  });
+  it('should return the place-name value if a place-image-alt value does not exist', () => {
+    expect(result(null, 'place-name value')).to.equal('place-name value');
+  });
+  it('should return the place-image-alt value when it has been given', () => {
+    expect(result('place-image-alt description', 'place-name value')).to.equal('place-image-alt description');
   });
 });


### PR DESCRIPTION
### In the review data, if there is no entry in the place-image-alt key, fill it with the value of place-name.

#### How to test:
* At the moment all `place-image-alt` keys in `places.yml` have a value.
* To test, go to `places.yml` and remove the value in one of the `place-image-alt` keys. I recommend using Gaucho as the `place-name` and `place-image-alt` values listed in the data are different.
* Save changes, then run `npm run dev`.
* Using browser developer tools, look for the alt tag for the place you selected to alter data for.

#### Expected output using Gaucho:
With place-image-alt value

![with place-image-alt value](https://user-images.githubusercontent.com/12678977/28892623-9af0a1bc-779c-11e7-8c00-98ac9206fbfe.png)

Without place-image-alt value

![without place-image-alt value](https://user-images.githubusercontent.com/12678977/28892633-a86e4664-779c-11e7-8fac-1a1044c300f4.png)

### Additional request:
* Check to see that I have all the necessary tests. Am I missing any tests? 



