### PR TITLE
feat: refactor review page header styles

### DIFF
--- a/source/scss/_review.scss
+++ b/source/scss/_review.scss
@@ -153,6 +153,9 @@
       @include primary-font();
       color: $color-sparkblue-dark;
       font-size: 2.25em;
+      overflow-wrap: break-word;
+      word-wrap: break-word; // required for Edge, IE & Opera Mini
+      hyphens: auto; // partial support in Chrome, Opera and Android
       margin-bottom: 0;
       margin: 0;
       padding: 0em;


### PR DESCRIPTION
### Adjust padding and font size in the review page header title and name styles so that the name of the place displays completely inside of the title area and has appropriate padding.

Look at the place name in the header of the following review pages noted in issue #197.
* Bareburger
* Sleepy Bee Cafe
* Canal Street Arcade and Deli

### Here's an example using Bareburger.
Before:
![29476051-3f96366a-8430-11e7-84cc-67970324d630](https://user-images.githubusercontent.com/12678977/29568551-aacec3a2-871e-11e7-8d1c-cf05f3333367.png)

After:
<img width="330" alt="screen shot 2017-08-22 at 9 47 01 am" src="https://user-images.githubusercontent.com/12678977/29568635-eadd8258-871e-11e7-9391-c3876f11b814.png">

### Review on Heroku
https://sparkeats-pr-199.herokuapp.com/index.html
The username and password are stored in 1Password. You can find it by doing a quick search for 'eats'.
