### PR TITLE
feat: update place url component

### DIFF
--- a/source/partials/_address.hbs
+++ b/source/partials/_address.hbs
@@ -1,5 +1,7 @@
 <address class="sparkeats-address">
   <p>{{place.address}}</p>
   <p>{{place.phone}}</p>
-  <p><a class="sparkeats-address__link" href="{{place.place-url}}">{{place.place-website-display}}</a></p>
 </address>
+<div class="sparkeats-address__url">
+  <a class="sparkeats-address__url-link" href="{{place.place-url}}">Visit Site</a>
+</div>

--- a/source/scss/_layout.scss
+++ b/source/scss/_layout.scss
@@ -56,15 +56,26 @@ li:not([class]){
   color: $color-black;
   text-align: center;
   line-height: 1.25em;
-  margin: 2.25em 2.5em 2.5em 2.5em;
-  &__link {
-    font-size: 0.85em;
+  margin: 2.25em 2.5em 0 2.5em;
+  &__url {
+    padding: 0.5em 0 2em 0;
+  }
+  &__url-link {
+    @include primary-font();
+    -webkit-font-smoothing: antialiased;
+    background-color: $color-white;
     color: $color-jellybean-blue;
     text-decoration: none;
+    letter-spacing: 0.075em;
     line-height: 1.5em;
-    border-bottom: 0.1em solid $color-jellybean-blue;
+    padding: 0.5em 1em;
+    transition: all 500ms cubic-bezier(0,1.08,.65,.98);
     @media (min-width: 21.13em) {
       font-size: 0.938em;
+    }
+    &:hover {
+      background-color: $color-sparkblue-dark;
+      color: $color-white;
     }
   }
 }

--- a/source/scss/_place-card.scss
+++ b/source/scss/_place-card.scss
@@ -44,7 +44,7 @@
     right: 0;
     position: absolute;
     transition: all 500ms cubic-bezier(0,1.08,.65,.98);
-    &:hover{
+    &:hover {
       color: $color-sparkblue-light;
       background-color: darken($color-fountain-blue, 20%);
     }


### PR DESCRIPTION
The website url that sits in the Sparkeats address partial displays in both the place card and on the review page.

Update the url to a button that displays well in both components. A button will eliminate excessively long website url text that does not display well.

Before:
<img width="394" alt="29568840-9da71296-871f-11e7-9ee6-3d8d35c6eed5" src="https://user-images.githubusercontent.com/12678977/29582715-be596eea-874b-11e7-92ef-a49928ea738b.png">

After:
![after](https://user-images.githubusercontent.com/12678977/29582619-63a209ee-874b-11e7-9d9e-68daeab704ce.png)
Note that the `Visit Site` button on the left place card is white and blends into the background of the place card. The button on the right place card has its hover state implemented.

Review on Heroku:
https://sparkeats-pr-204.herokuapp.com
The username and password can be retrieved from 1Password via a quick search of 'eats'.