### PR TITLE
chore: update footer BUILT BY copy

### DIFF
--- a/source/partials/_sparkeats-footer.hbs
+++ b/source/partials/_sparkeats-footer.hbs
@@ -18,8 +18,6 @@
     <div class="sparkeats-column__twothirds">
       <h4 class="sparkeats-column__heading">Your chefs</h4>
       <p class="sparkeats-footer__copy">This site is proudly dished up by the <a class="sparkeats-footer__link" href="http://apprentices.seesparkbox.com/">Sparkbox Apprenticeship v7.0</a>. Please report corrections to the appropriate reviewing <a class="sparkeats-footer__link" href="https://seesparkbox.com/team">Sparkboxer</a>.</p>
-      <a class="sparkeats-footer__link sparkeats-footer__link-span" href="http://www.bettybaker.us">Betty Baker</a>
-      <a class="sparkeats-footer__link" href="http://www.heathercancode.com">Heather Taylor</a>
     </div>
 </section>
 


### PR DESCRIPTION
The BUILT BY section of the footer contains a single line of text: 
![screen shot 2017-08-24 at 2 48 57 pm](https://user-images.githubusercontent.com/12678977/29683281-c8cb4eb6-88db-11e7-8a4b-0614a7bbcf28.png)

Should we add more content to this?
