### PR TITLE
refactor: remove hyphen option in scss

### DIFF
--- a/source/scss/_review.scss
+++ b/source/scss/_review.scss
@@ -151,7 +151,6 @@
       font-size: 2.25em;
       overflow-wrap: break-word;
       word-wrap: break-word; // required for Edge, IE & Opera Mini
-      hyphens: auto; // partial support in Chrome, Opera and Android
       margin-bottom: 0;
       margin: 0;
       padding: 0em;


### PR DESCRIPTION
For right now, I think the hyphen option is causing more problems than it solves. I'm leaving the word-wrapping, though.