### PR TITLE
feat: add redirect from http to https to server tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "glob": "^7.1.1",
     "globby": "^6.1.0",
     "handlebars": "^4.0.8",
+    "heroku-ssl-redirect": "^0.0.4",
     "marshmallows": "^0.1.1",
     "mkdirp": "^0.5.1",
     "mocha": "^3.4.2",

--- a/tasks/server.js
+++ b/tasks/server.js
@@ -2,6 +2,7 @@
 
 const shell = require('shelljs');
 const express = require('express');
+const sslRedirect = require('heroku-ssl-redirect');
 
 const app = express();
 const path = require('path');
@@ -15,6 +16,8 @@ if (process.env.NODE_ENV === 'production') {
   // process.env.PORT lets the port be set by Heroku
   const port = process.env.PORT || 5000;
 
+  app.use(sslRedirect());
+
   app.listen(port, function () {
     console.log('Our app is running on http://localhost:' + port);
   });
@@ -25,6 +28,7 @@ if (process.env.NODE_ENV === 'production') {
   app.use(express.static(path.join(__dirname, '../dist')));
   // use express to look to send styles and other assets to server
   app.use(express.static(path.join(__dirname, '../public')));
+
 } else {
   // start development server (npm run dev) to watch and update html and css files
   shell.exec("browser-sync start --server --index 'dist/index.html' --serveStatic 'dist' 'public'");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,6 +2531,10 @@ hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
+heroku-ssl-redirect@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/heroku-ssl-redirect/-/heroku-ssl-redirect-0.0.4.tgz#21ba0707aa503b50a412a0946abfaa88ef7d082c"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -3075,6 +3079,18 @@ lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
+lodash._bindcallback@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+
+lodash._createassigner@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz#838a5bae2fdaca63ac22dee8e19fa4e6d6970b11"
+  dependencies:
+    lodash._bindcallback "^3.0.0"
+    lodash._isiterateecall "^3.0.0"
+    lodash.restparam "^3.0.0"
+
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
@@ -3082,6 +3098,14 @@ lodash._getnative@^3.0.0:
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash.assign@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-3.2.0.tgz#3ce9f0234b4b2223e296b8fa0ac1fee8ebca64fa"
+  dependencies:
+    lodash._baseassign "^3.0.0"
+    lodash._createassigner "^3.0.0"
+    lodash.keys "^3.0.0"
 
 lodash.assign@^4.2.0:
   version "4.2.0"
@@ -3126,6 +3150,10 @@ lodash.keys@^3.0.0:
 lodash.mergewith@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz#150cf0a16791f5903b8891eab154609274bdea55"
+
+lodash.restparam@^3.0.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash@^3.10.1:
   version "3.10.1"


### PR DESCRIPTION
### Update server.js to redirect `http` requests to `https` 
Using the heroku-ssl-redirect node module:
https://www.npmjs.com/package/heroku-ssl-redirect

### To test
Go to the deployment for this pull request: http://sparkeats-pr-244.herokuapp.com/
Note that the link above links to `http`
Your browser window should show the `https`
