### PR TITLE
feat: Ignore sparkeats-v2

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,4 +14,6 @@ ratings:
   paths:
   - "**.js"
   - "**.scss"
-exclude_paths: []
+exclude_paths: [
+  "/sparkeats-v2"
+]

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+sparkeats-v2/


### PR DESCRIPTION
Ignore sparkeats-v2 directory in `.eslintignore` and exclude sparkeats-v2 directory path in `.codeclimate.yml` so CodeClimate doesn't see it while moving code from v1 to v2.