### PR TITLE
fix: Adjust footer-pins padding and center (EATS-69)

### DIFF
--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -197,10 +197,11 @@ li:not([class]) {
   background-color: $color-sparkblue-light;
   background-image: url(/design/sparkeats_footer-pins.svg);
   background-repeat: repeat-x;
+  background-position: center;
   width: 100%;
   max-width: 100%;
   height: 5em;
-  padding-bottom: 1.5em;
+  padding: 2rem 0;
 }
 
 .place-new {
@@ -208,7 +209,7 @@ li:not([class]) {
   margin-top: 2em;
   &__link {
     @include secondary-font(500);
-    font-size: 0.90em;
+    font-size: 0.9em;
     color: $color-jellybean-blue;
     text-decoration: none;
     border-bottom: 1px solid $color-jellybean-blue;

--- a/assets/styles/_new.scss
+++ b/assets/styles/_new.scss
@@ -240,6 +240,7 @@
   font-size: 1.25rem;
   font-weight: bold;
   padding: 0.75rem;
+  margin-bottom: 6rem;
   &:hover,
   &:focus {
     color: $color-sparkblue-light;

--- a/assets/styles/_review.scss
+++ b/assets/styles/_review.scss
@@ -172,6 +172,7 @@
 }
 
 .review-nav {
+  margin: 6rem 0;
   -webkit-font-smoothing: antialiased;
   max-width: 58.5em;
   width: 100%;


### PR DESCRIPTION
# Footer pins / buttons layout bugs (EATS-69)

I adjusted footer-pins padding and centered them and then added consistent margin between footer-pins and buttons.