### PR TITLE
fix: Center Place cards on small screens (Android 6)

### DIFF
--- a/assets/styles/_grid.scss
+++ b/assets/styles/_grid.scss
@@ -30,7 +30,7 @@
     text-align: center;
   }
   &::after {
-    content: "";
+    content: '';
     display: table;
     clear: both;
   }
@@ -38,7 +38,6 @@
     list-style: none;
     vertical-align: top;
     margin: 2em auto;
-    min-width: 18em;
     width: 23em;
     max-width: 100%;
     @media (min-width: $bp-small-screen) {
@@ -48,6 +47,7 @@
       // use inline-block for browsers and devices that do not support flexbox
       display: inline-block;
       max-width: 32%;
+      min-width: 18em;
     }
     &.hidden {
       display: none;

--- a/assets/styles/_homepage.scss
+++ b/assets/styles/_homepage.scss
@@ -1,4 +1,4 @@
 .wrapper--homepage {
   background-color: $color-sparkblue-light;
-  padding: 2rem;
+  padding: 2rem 1rem;
 }


### PR DESCRIPTION
# Center Place cards on small screens

The `min-width` set on `.place-card__list-item` in `_grid.scss` is causing the centering issue on screens smaller than about 380px. I set a lower default `min-width: 16em` and set `min-width: 18em` in the media query.