### PR TITLE
docs: Update README for Sparkeats 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,15 @@
-# sparkeats-v-2
+# Sparkeats
 
-a [Sails v1](https://sailsjs.com) application
+**Sparkboxers review food and drink places so you can eat well**
 
+Built with [Sails.js](https://sailsjs.com/).
 
-### Links
+Welcome to Sparkeats! The purpose of this site is to provide reviews and recommendations from sparkboxers of places we love to eat and drink.
 
-+ [Get started](https://sailsjs.com/get-started)
-+ [Sails framework documentation](https://sailsjs.com/documentation)
-+ [Version notes / upgrading](https://sailsjs.com/documentation/upgrading)
-+ [Deployment tips](https://sailsjs.com/documentation/concepts/deployment)
-+ [Community support options](https://sailsjs.com/support)
-+ [Professional / enterprise options](https://sailsjs.com/enterprise)
+## To Run the Site Locally
 
+Instructions for running the site locally are saved in a wiki here: [https://github.com/sparkbox/sparkeats/wiki/Running-Sparkeats-Locally](https://github.com/sparkbox/sparkeats/wiki/Running-Sparkeats-Locally)
 
-### Version info
+#### License
 
-This app was originally generated on Wed May 23 2018 17:06:24 GMT-0400 (EDT) using Sails v1.0.2.
-
-<!-- Internally, Sails used [`sails-generate@1.15.25`](https://github.com/balderdashy/sails-generate/tree/v1.15.25/lib/core-generators/new). -->
-
-
-
-<!--
-Note:  Generators are usually run using the globally-installed `sails` CLI (command-line interface).  This CLI version is _environment-specific_ rather than app-specific, thus over time, as a project's dependencies are upgraded or the project is worked on by different developers on different computers using different versions of Node.js, the Sails dependency in its package.json file may differ from the globally-installed Sails CLI release it was originally generated with.  (Be sure to always check out the relevant [upgrading guides](https://sailsjs.com/upgrading) before upgrading the version of Sails used by your app.  If you're stuck, [get help here](https://sailsjs.com/support).)
--->
-
+&copy; Sparkbox Apprenticeship 7.0 and 8.0


### PR DESCRIPTION
# Update README for Sparkeats 2.0

I removed information that isn't relevant to the Sails app and updated the [Running Sparkeats Locally](https://github.com/sparkbox/sparkeats/wiki/Running-Sparkeats-Locally) wiki.

What should be done with the Wiki pages that are no longer relevant to the Sails app (e.g.  Instructions to add places, reviews, and images through pull-requests)?