### PR TITLE
fix (Homepage): Only show Places with Reviews

### DIFF
--- a/api/helpers/get-number-of-reviews.js
+++ b/api/helpers/get-number-of-reviews.js
@@ -16,8 +16,9 @@ module.exports = {
   },
 
   fn: ({ ratings, currentPlace }, exits) => {
-    const n = ratings.filter(rating => rating.placeId === currentPlace.id)
-      .length;
-    return exits.success(`${n} ${n === 1 ? 'Review' : 'Reviews'}`);
+    const numberOfReviews = ratings.filter(
+      rating => rating.placeId === currentPlace.id
+    ).length;
+    return exits.success(numberOfReviews);
   },
 };

--- a/views/partials/place-card-container.ejs
+++ b/views/partials/place-card-container.ejs
@@ -1,7 +1,9 @@
 <section class="place-card__container">
   <ul class="place-card__list">
     <% dataForView.forEach(place => { %>
-    <%- partial('./place-card', { place }) %>
+      <% if (place.numberOfReviews) { %>
+        <%- partial('./place-card', { place }) %>
+      <% } %>
     <% }) %>
   </ul>
 </section>

--- a/views/partials/place-card-footer.ejs
+++ b/views/partials/place-card-footer.ejs
@@ -1,4 +1,8 @@
 <a class="place-card__footer-link" href="/places/<%= place.id %>">
 <!-- number of reviews -->
-<%- place.numberOfReviews %>
+<% if (place.numberOfReviews > 1) { %>
+  <%= place.numberOfReviews %> Reviews
+<% } else { %>
+  <%= place.numberOfReviews %> Review
+<% } %>
 </a>


### PR DESCRIPTION
# Hide Places without Reviews (EATS-77)

If a place is added without a review, it is not displayed on the homepage. It is still created in the database. Multiple places can be created with the same name, so the same place can be created again to add a review since places do not have to be unique.
