### PR TITLE
chore: Disable blueprints

### DIFF
--- a/config/blueprints.js
+++ b/config/blueprints.js
@@ -10,32 +10,28 @@
  */
 
 module.exports.blueprints = {
+  /***************************************************************************
+   *                                                                          *
+   * Automatically expose implicit routes for every action in your app?       *
+   *                                                                          *
+   ***************************************************************************/
+
+  actions: false,
 
   /***************************************************************************
-  *                                                                          *
-  * Automatically expose implicit routes for every action in your app?       *
-  *                                                                          *
-  ***************************************************************************/
+   *                                                                          *
+   * Automatically expose RESTful routes for your models?                     *
+   *                                                                          *
+   ***************************************************************************/
 
-  // actions: false,
-
-
-  /***************************************************************************
-  *                                                                          *
-  * Automatically expose RESTful routes for your models?                     *
-  *                                                                          *
-  ***************************************************************************/
-
-  // rest: true,
-
+  rest: false,
 
   /***************************************************************************
-  *                                                                          *
-  * Automatically expose CRUD "shortcut" routes to GET requests?             *
-  * (These are enabled by default in development only.)                      *
-  *                                                                          *
-  ***************************************************************************/
+   *                                                                          *
+   * Automatically expose CRUD "shortcut" routes to GET requests?             *
+   * (These are enabled by default in development only.)                      *
+   *                                                                          *
+   ***************************************************************************/
 
-  // shortcuts: true,
-
+  shortcuts: false,
 };


### PR DESCRIPTION
# Disable blueprints (EATS-78)

This disables data to be visible at routes using Sails.js [blueprints](https://sailsjs.com/documentation/reference/configuration/sails-config-blueprints).
