### PR TITLE
fix: Add a hidden h1 for the Sparkeats header for screen readers

### DIFF
--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -25,6 +25,14 @@ li:not([class]) {
   display: flex;
   justify-content: center;
   max-width: 100%;
+  &__title {
+    position: absolute;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    text-indent: -9999px;
+    overflow: hidden;
+  }
   &__logo {
     display: block;
     background: url(/design/sparkeats_logomark.svg) center no-repeat;

--- a/views/partials/sparkeats-header.ejs
+++ b/views/partials/sparkeats-header.ejs
@@ -1,3 +1,4 @@
 <header class="sparkeats-header">
-  <a class="sparkeats-header__logo" href="/" alt="Sparkeats"></a>
+  <h1 class="sparkeats-header__title">Sparkeats</h1>
+  <a class="sparkeats-header__logo" href="/" aria-label="Sparkeats logo"></a>
 </header>

--- a/views/partials/sparkeats-subtitle.ejs
+++ b/views/partials/sparkeats-subtitle.ejs
@@ -1,1 +1,1 @@
-<h2 class="sparkeats-subtitle">sparkboxers review food and drink places </br>so you can eat well</h2>
+<h2 class="sparkeats-subtitle">sparkboxers review food and drink places so you can eat well</h2>


### PR DESCRIPTION
# Add a hidden h1 for the Sparkeats header for screen readers