### PR TITLE
fix: Make star ratings accessible with voice over

### DIFF
--- a/api/controllers/PlaceController.js
+++ b/api/controllers/PlaceController.js
@@ -34,6 +34,11 @@ module.exports = {
         placeWebsiteDisplay,
       } = place;
 
+      let { stars, rating } = sails.helpers.getAvgNumberOfStars(
+        reviews,
+        place.id
+      );
+
       return {
         id,
         name,
@@ -45,8 +50,9 @@ module.exports = {
         placeImageAlt,
         placeURL,
         placeWebsiteDisplay,
-        avgNumberOfStars: sails.helpers.getAvgNumberOfStars(reviews, place),
-        numberOfReviews: sails.helpers.getNumberOfReviews(reviews, place),
+        numberOfStars: stars,
+        rating,
+        numberOfReviews: sails.helpers.getNumberOfReviews(reviews, place.id),
       };
     });
 

--- a/api/controllers/ReviewController.js
+++ b/api/controllers/ReviewController.js
@@ -44,6 +44,11 @@ module.exports = {
       return res.serverError(err);
     }
 
+    let { stars, rating } = sails.helpers.getAvgNumberOfStars(
+      reviews,
+      place.id
+    );
+
     const dataForView = {
       id: place.id,
       name: place.placeName,
@@ -54,16 +59,30 @@ module.exports = {
       address: place.address,
       city: place.city,
       state: place.state,
-      avgNumberOfStars: sails.helpers.getAvgNumberOfStars(reviews, place),
-      numberOfReviews: sails.helpers.getNumberOfReviews(reviews, place),
-      reviews: reviews.map(review => ({
-        reviewerName: review.reviewerName,
-        reviewText: review.reviewText,
-        reviewImageFileName: review.reviewImageFileName,
-        reviewImageAlt: review.reviewImageAlt,
-        placeId: review.placeId,
-        numberOfStars: sails.helpers.getNumberOfStars(review.numberOfStars),
-      })),
+      numberOfStars: stars,
+      rating,
+      numberOfReviews: sails.helpers.getNumberOfReviews(reviews, place.id),
+      reviews: reviews.map(
+        ({
+          reviewerName,
+          reviewText,
+          reviewImageFileName,
+          reviewImageAlt,
+          numberOfStars,
+          placeId,
+        }) => {
+          const { stars, rating } = sails.helpers.getNumberOfStars(numberOfStars);
+          return {
+            reviewerName,
+            reviewText,
+            reviewImageFileName,
+            reviewImageAlt,
+            placeId,
+            numberOfStars: stars,
+            rating
+          };
+        }
+      ),
     };
 
     return res.view('pages/reviews/reviews', { place: dataForView });

--- a/api/helpers/get-avg-number-of-stars.js
+++ b/api/helpers/get-avg-number-of-stars.js
@@ -10,15 +10,15 @@ module.exports = {
       type: 'ref',
       description: 'The reviews of a single place.',
     },
-    currentPlace: {
+    placeId: {
       type: 'ref',
       description: 'A single place.',
     },
   },
 
-  fn: ({ reviews, currentPlace }, exits) => {
+  fn: ({ reviews, placeId }, exits) => {
     const placeRatings = reviews
-      .filter(review => review.placeId === currentPlace.id)
+      .filter(review => review.placeId === placeId)
       .map(item => item.numberOfStars);
 
     const avgRating = Math.round(
@@ -26,8 +26,8 @@ module.exports = {
       placeRatings.length
     );
 
-    const result = sails.helpers.getNumberOfStars(avgRating);
+    const { stars, rating } = sails.helpers.getNumberOfStars(avgRating);
 
-    return exits.success(result);
+    return exits.success({ stars, rating });
   },
 };

--- a/api/helpers/get-number-of-reviews.js
+++ b/api/helpers/get-number-of-reviews.js
@@ -9,15 +9,15 @@ module.exports = {
       type: 'ref',
       description: 'The ratings of a place.',
     },
-    currentPlace: {
+    placeId: {
       type: 'ref',
       description: 'A single place.',
     },
   },
 
-  fn: ({ ratings, currentPlace }, exits) => {
+  fn: ({ ratings, placeId }, exits) => {
     const numberOfReviews = ratings.filter(
-      rating => rating.placeId === currentPlace.id
+      rating => rating.placeId === placeId
     ).length;
     return exits.success(numberOfReviews);
   },

--- a/api/helpers/get-number-of-stars.js
+++ b/api/helpers/get-number-of-stars.js
@@ -12,18 +12,21 @@ module.exports = {
   },
 
   fn: ({ rating }, exits) => {
-    const filledStar = `<img class="place-card__star" src="../design/sparkeats_star.svg" alt="review star">`;
-    const emptyStar = `<img class="place-card__star" src="../design/sparkeats_star_empty.svg" alt="review star">`;
-    let result = '';
+    const filledStar = `<img class="place-card__star" src="../design/sparkeats_star.svg" alt="review star" aria-hidden="true">`;
+    const emptyStar = `<img class="place-card__star" src="../design/sparkeats_star_empty.svg" alt="review star" aria-hidden="true">`;
+    let stars = '';
 
     for (let i = 0; i < rating; i += 1) {
-      result += filledStar;
+      stars += filledStar;
     }
     if (5 - rating !== 0) {
       for (let i = 0; i < 5 - rating; i += 1) {
-        result += emptyStar;
+        stars += emptyStar;
       }
     }
-    return exits.success(result);
+
+    rating = rating > 1 ? `${rating} stars` : `${rating} star`;
+
+    return exits.success({ stars, rating });
   },
 };

--- a/views/partials/place-name-city-state.ejs
+++ b/views/partials/place-name-city-state.ejs
@@ -2,6 +2,3 @@
   <a class="place-card__name-link" href="/places/<%= place.id %>"><%= place.name %></a>
 </h1>
 <h2 class="place-card__city"><%= place.city %>, <%= place.state %></h2>
-<div>
-<%- place.avgNumberOfStars %>
-</div>

--- a/views/partials/review-container.ejs
+++ b/views/partials/review-container.ejs
@@ -7,7 +7,9 @@
     <h1 class="review-submission__reviewer">
       <%= review.reviewerName %>
     </h1>
-    <%- review.numberOfStars %>
+    <div class="place-card__star-rating" aria-label="<%= review.rating %>">
+      <%- review.numberOfStars %>
+    </div>
       <h2 class="review-submission__title">Comments</h2>
       <p class="review-submission__review">
         <%= review.reviewText %>

--- a/views/partials/review-overview.ejs
+++ b/views/partials/review-overview.ejs
@@ -7,7 +7,9 @@
         <%- place.numberOfReviews %> Review
       <% } %>
     </p>
-    <%- place.avgNumberOfStars %>
+    <div class="place-card__star-rating" aria-label="<%= place.rating %>">
+      <%- place.numberOfStars %>
+    </div>
   </div>
   <div class="review-overview__address">
     <%- partial('./address') %>

--- a/views/partials/star-rating.ejs
+++ b/views/partials/star-rating.ejs
@@ -1,3 +1,4 @@
-<div>
+<div class="place-card__star-rating" aria-label="<%= place.rating %>">
 <!-- average star rating -->
+  <%- place.numberOfStars %>
 </div>


### PR DESCRIPTION
# Make star ratings accessible with voice over

I added an `aria-label` to the `div` that groups the star images and added `aria-hidden=true` to the images themselves. Now the voice over says e.g. "5 stars, group" and ignore the individual stars.