### PR TITLE
chore(FSA2020-71): fix script typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "lift": "sails lift --drop",
-    "dev": "concurrently \"npm run sass-watch\" \"npm run server\"",
+    "dev": "concurrently \"npm run sass:watch\" \"npm run server\"",
     "start": "npm run build && sails lift",
     "build": "npm run sass && npm run postcss",
     "sass": "node-sass assets/styles/main.scss .tmp/styles/main.css",


### PR DESCRIPTION
# [FSA2020-71](https://sparkbox.atlassian.net/browse/FSA2020-71)

## Description

Change `sass-watch` to `sass:watch` to run the correct script in dev task

### To Validate

* Check that this build has not failed.
* Pull down `FSA2020-71--script-typo` branch
* Run `npm run dev` and confirm that it logs this in the first several lines of the output:
```
sparkeats-v-2@0.0.0 sass:watch /Users/melissa/Workspace/sparkeats
node-sass --watch assets/styles/main.scss .tmp/styles/main.css
```