### PR TITLE
FSA2020-124-Fix sass:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "start": "npm run build && sails lift",
     "build": "npm run sass && npm run postcss",
     "sass": "node-sass assets/styles/main.scss .tmp/styles/main.css",
-    "sass:watch": "node-sass --watch assets/styles:.tmp/styles",
+    "sass:watch": "node-sass --watch assets/styles -o .tmp/styles",
     "postcss": "postcss --use autoprefixer -c tasks/postcss.config.json .tmp/styles/main.css -d .tmp/styles/",
     "server": "nodemon app.js & browser-sync start --proxy http://localhost:1337 --files \".tmp/styles/\" \"views/\" --reload-delay 1100",
     "test:unit": "mocha test/unit/*.test.js --require test-helper.js --require @babel/register",


### PR DESCRIPTION
# Update sass:watch script

## Description
The sass watch script was previously configured to watch the legacy
styles directory. Update input/output paths in order to watch
both, legacy and refresh styling changes.

### To Validate

* [ ] Check that this build has not failed.
* [ ] Pull down all related branches.
* [ ] Confirm npm test passes.
* [ ] Go to `localhost:3000/refresh`
* [ ] In `assets/styles/refresh.scss` on line 66 paste the following: `.sparkeats-header {color: red; }`
* [ ] Confirm text color change and remove the styling that was just added. 
