### PR TITLE
Prevent duplicate places from being created

### DIFF
--- a/api/models/Place.js
+++ b/api/models/Place.js
@@ -50,4 +50,17 @@ module.exports = {
       via: 'placeId',
     },
   },
+  async beforeCreate(values, proceed) {
+    const places = await Place.findOne({
+      where: {
+        address: values.address,
+        city: values.city,
+        state: values.state,
+      },
+    });
+    if (places) {
+      return proceed(new Error('This place already exists in the database'));
+    }
+    return proceed();
+  },
 };


### PR DESCRIPTION
# Prevent duplicate places from being created

## Description
This PR adds a beforeCreate lifecycle callback to the Place.js model file. This lifecycle callback checks to see if a place which matches the address, city, and state already exists in the database. If there is a place which matches, an error will be thrown.

[FSA2020-94](https://sparkbox.atlassian.net/browse/FSA2020-94?atlOrigin=eyJpIjoiNjY1ZGEzZThlN2NiNDFiZTgyZmVhZGJmMWY4NTg1MzEiLCJwIjoiaiJ9)

## Validation
* [ ] This PR has code changes, and our linters still pass.

### To Validate
* Check that this build has not failed.
* Pull down all related branches.
* Confirm that all tests pass.
* Run `npm run dev` to start the server
* Try to add a place to Sparkeats which already exists
* Verify that the you receive an error if you try to add a place which already exists within the database
