### PR TITLE
Prevent Duplicate Places

### DIFF
--- a/api/models/Place.js
+++ b/api/models/Place.js
@@ -50,4 +50,17 @@ module.exports = {
       via: 'placeId',
     },
   },
+  async beforeCreate(values, proceed) {
+    const place = await Place.findOne({
+      where: {
+        address: values.address,
+        city: values.city,
+        state: values.state,
+      },
+    });
+    if (place) {
+      return proceed(new Error('This place already exists in the database'));
+    }
+    return proceed();
+  },
 };

--- a/views/pages/places/new.ejs
+++ b/views/pages/places/new.ejs
@@ -28,7 +28,7 @@
 
       <div class="form__field form__required-indicator" >
         <label class="form__label" for="address" aria-hidden="true">Address</label>
-        <input id="address" class="form__input" type="text" name="address" placeholder="Address"
+        <input id="address" class="form__input" type="text" name="address" placeholder="123 Alphabet Street"
           required>
       </div>
 


### PR DESCRIPTION
# Prevent duplicate places from being created

## Description
This PR adds a beforeCreate lifecycle callback to the Place.js model file. This lifecycle callback checks to see if a place which matches the address, city, and state already exists in the database. If there is a place which matches, an error will be thrown.

[FSA2020-94](https://sparkbox.atlassian.net/browse/FSA2020-94?atlOrigin=eyJpIjoiNjY1ZGEzZThlN2NiNDFiZTgyZmVhZGJmMWY4NTg1MzEiLCJwIjoiaiJ9)

## Validation
* [x] This PR has code changes, and our linters still pass.

### To Validate
* Check that this build has not failed.
* Pull down all related branches.
* Confirm that all tests pass.
* Run `npm run dev` to start the server
* Try to add a place to Sparkeats which already exists
* Verify that the you receive an error if you try to add a place which already exists within the database
