### PR TITLE
ci: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: deploy
+on:
+  push:
+    branches:
+      - main
+jobs:
+  github-pages:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+
+      - name: Install Yarn
+        run: npm install --location=global yarn
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build src
+        run: yarn build
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "$(git log -n 1 --pretty=format:%an)"
+          git config --global user.email "$(git log -n 1 --pretty=format:%ae)"
+
+      - name: Commit and push changes to gh-pages branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd dist
+          echo > .nojekyll
+
+          git init
+          git checkout -b gh-pages
+          git add -A
+          git commit -m 'ci: deploy'
+
+          git remote add origin https://sparkbox:$GITHUB_TOKEN@github.com/sparkbox/sparkeats.git
+
+          git push --force origin gh-pages:gh-pages

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,5 +1,5 @@
-name: sparkeats-web
-on: [push, pull_request]
+name: web
+on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,6 +11,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+
       - name: Install Yarn
         run: npm install --location=global yarn
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ resource that may be used to explore and build with different
 technologies. The first example of this is a [React TypeScript
 rebuild](https://github.com/orgs/sparkbox/projects/1/views/1) of the Sparkeats web app.
 
+## Examples
+
+- [Sparkeats Refresh](http://eats.seesparkbox.com/refresh)
+- [Sparkeats: React TypeScript](https://sparkbox.github.io/sparkeats)
+
 ## Setup
 
 ### Install Yarn

--- a/index.html
+++ b/index.html
@@ -2,10 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-
     <!-- Viewport mobile tag for sensible mobile support -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
     <meta property="og:title" content="Sparkeats" />
     <meta
       property="og:description"
@@ -13,7 +11,6 @@
     />
     <meta property="og:image" content="open-graph.png" />
     <meta property="og:url" content="https://eats.seesparkbox.com/" />
-
     <link
       rel="apple-touch-icon-precomposed"
       sizes="57x57"
@@ -76,13 +73,40 @@
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png" />
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css?family=Oswald:400,700|Roboto+Condensed:300,400,700|Roboto:400,700,900&display=swap"
+      href="https://fonts.googleapis.com/css?family=Oswald:400,700|Roboto+Condensed:300,400,700|Roboto:400,700,900&amp;display=swap"
     />
-
     <title>Sparkeats</title>
   </head>
   <body>
     <div id="root"></div>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script checks to see if a redirect is present in the query string,
+      // converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function (l) {
+        if (l.search[1] === "/") {
+          var decoded = l.search
+            .slice(1)
+            .split("&")
+            .map(function (s) {
+              return s.replace(/~and~/g, "&");
+            })
+            .join("?");
+          window.history.replaceState(
+            null,
+            null,
+            l.pathname.slice(0, -1) + decoded + l.hash
+          );
+        }
+      })(window.location);
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Single Page Apps for GitHub Pages</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname
+            .slice(1)
+            .split("/")
+            .slice(pathSegmentsToKeep)
+            .join("/")
+            .replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { locations } from './locations';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={`${import.meta.env['BASE_URL']}`}>
       <Routes>
         <Route path="/" element={<App />}>
           <Route path="/" element={<HomePage locations={locations} />} />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,8 @@ import App from './App';
 import HomePage from './components/HomePage';
 import { locations } from './locations';
 
+window.__SPARKEATS_VERSION__ = import.meta.env['VITE_SPARKEATS_VERSION'];
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter basename={`${import.meta.env['BASE_URL']}`}>

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,6 +1,10 @@
 export {};
 
 declare global {
+  interface Window {
+    __SPARKEATS_VERSION__: string;
+  }
+
   type Location = {
     id: number;
     name: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import childProcess from 'child_process'
 
-// https://vitejs.dev/config/
+const latestCommitHash = childProcess 
+    .execSync('git rev-parse --short HEAD')
+    .toString()
+    .trimEnd();
+
+process.env.VITE_SPARKEATS_VERSION = latestCommitHash;
+
 export default defineConfig({
   base: '/sparkeats/',
   plugins: [react()]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/sparkeats/',
   plugins: [react()]
 })


### PR DESCRIPTION
## What changed?

ci: add GitHub Pages deploy workflow

Client-side routing uses this guide https://github.com/rafgraph/spa-github-pages

docs: add Examples section to README

ci: rename web workflow

Resolves #391 

## How did you test the changes?

I ran the deploy script locally: `./deploy.sh`

I verified that the routes work:

- https://sparkbox.github.io/sparkeats/
- https://sparkbox.github.io/sparkeats/locations/1
- https://sparkbox.github.io/sparkeats/locations/new
- https://sparkbox.github.io/sparkeats/reviews/new

I tested the workflow deploy by temporarily changing the deploy branch to `ci-deploy-github-pages`.
