### PR TITLE
feat: SiteHeader has been rebuilt

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -67,7 +67,7 @@
 // 6. Components
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
-@import 'scss/components/sparkeats-header';
+@import 'scss/components/site-header';
 @import 'scss/components/buttons';
 @import 'scss/components/place-card';
 @import 'scss/components/stars';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { Outlet } from 'react-router-dom'
 import './App.scss'
+import { SiteHeader } from './components/SiteHeader';
 
 function App() {
   return (
     <div>
-      <header>Site Header</header>
+      <SiteHeader />
       <Outlet />
     </div>
   )

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,9 @@
+export const SiteHeader = () => {
+  return (
+    <header className="site-header">
+      <h1 className="site-header__title">Sparkeats by Sparkbox</h1>
+      <a className="site-header__logo" href="/" aria-label="Return to Sparkeats Homepage" />
+    </header>
+  );
+};
+

--- a/src/scss/components/_site-header.scss
+++ b/src/scss/components/_site-header.scss
@@ -1,4 +1,4 @@
-.sparkeats-header {
+.site-header {
   background-color: $primary-color;
   padding: 1em;
   box-sizing: border-box;


### PR DESCRIPTION
This pull request addresses issue #401 

## What changed?
- The `SiteHeader` component has been rebuilt from the old design.
- Updated some SCSS file names for a more consistent naming convention.
- Because nested landmarks fail aXe linting, I had to chose between a `nav` and a `header` element. ~Either works, so I followed the issue and used a `nav` element. This is a little weird with the `h1` element so I'm open to changing that.~ 
- Cypress is not yet set up, so no tests were added, but I following a format that should pass tests

## How did you test the changes?
- Manually
- Location pages ~are not yet set up~ exist, so I can manually test several routes, 
- This should show up anywhere that uses App.tsx

## Screenshots
![Screen Shot 2022-10-17 at 3 13 07 PM](https://user-images.githubusercontent.com/7475148/196262647-3aa66e4c-7096-4f27-8511-942e11b409c9.png)
![Screen Shot 2022-10-17 at 3 13 00 PM](https://user-images.githubusercontent.com/7475148/196262652-4087e34c-556f-4d6c-b976-a65d9e5174bd.png)
![Screen Shot 2022-10-17 at 3 15 49 PM](https://user-images.githubusercontent.com/7475148/196263126-84ff43d6-964a-47fb-bff7-5d9c9df7c167.png)
